### PR TITLE
fix(fts): remove contentless FTS5, sanitize hyphen queries, fix scan rules

### DIFF
--- a/docs/schema/memory_palace_schema.sql
+++ b/docs/schema/memory_palace_schema.sql
@@ -261,7 +261,6 @@ CREATE VIRTUAL TABLE IF NOT EXISTS claim_fts USING fts5(
     predicate,
     value,
     entity_name,
-    content = '',          -- contentless: we manage sync via triggers
     tokenize = 'porter unicode61'
 );
 
@@ -269,7 +268,6 @@ CREATE VIRTUAL TABLE IF NOT EXISTS entity_fts USING fts5(
     canonical_name,
     description,
     aliases,
-    content = '',
     tokenize = 'porter unicode61'
 );
 
@@ -277,7 +275,6 @@ CREATE VIRTUAL TABLE IF NOT EXISTS document_fts USING fts5(
     title,
     external_id,
     doc_type,
-    content = '',
     tokenize = 'porter unicode61'
 );
 

--- a/src/collections/ai_dev_governance.py
+++ b/src/collections/ai_dev_governance.py
@@ -52,6 +52,7 @@ COLLECTION_CONFIG = {
         "chunk",
         "phase",
         "risk_tier",
+        "bundle_type",
     ],
     "statuses": [
         "draft",
@@ -74,11 +75,16 @@ SCAN_RULES: list[tuple[str, str, dict[str, str]]] = [
     ("docs/planning/phase-", "risk-log", {"stage_produced": "plan"}),
     ("docs/planning/board/board-selection-", "board-selection", {"stage_produced": "plan"}),
     ("docs/planning/board/committee-review-packet-", "board-packet", {"stage_produced": "board-review"}),
+    ("docs/planning/board/board-composition-approval-", "board-decision", {"stage_produced": "board-review"}),
+    ("docs/planning/board/committee-opportunity-register-", "board-packet", {"stage_produced": "board-review"}),
     ("docs/planning/board/committee-virtual-meeting-", "meeting-record", {"stage_produced": "board-review"}),
     ("docs/planning/board/members/", "board-member-profile", {"stage_produced": "plan"}),
-    ("docs/plan/implementation-plan.md", "implementation-plan", {"stage_produced": "plan"}),
+    ("docs/planning/implementation-plan.md", "implementation-plan", {"stage_produced": "plan"}),
     ("docs/governance/exceptions.yaml", "exception-registry", {}),
     ("governance.yaml", "governance-manifest", {"stage_produced": "ingest"}),
+    ("docs/releases/astaire/", "validation-evidence", {"stage_produced": "release", "bundle_type": "astaire"}),
+    ("docs/releases/rtk/", "validation-evidence", {"stage_produced": "release", "bundle_type": "rtk"}),
+    ("docs/releases/bootstrap/", "validation-evidence", {"stage_produced": "release", "bundle_type": "bootstrap"}),
 ]
 
 
@@ -125,20 +131,20 @@ def scan_and_register(
 
     for rule_pattern, doc_type, base_tags in SCAN_RULES:
         full_pattern = root / rule_pattern
-        parent = full_pattern.parent if not full_pattern.is_dir() else full_pattern
 
-        if full_pattern.name and not full_pattern.is_dir():
-            # Specific file or prefix match
-            if str(rule_pattern).endswith("/"):
-                # Directory pattern — glob everything in it
-                files = sorted(parent.glob("*")) if parent.exists() else []
-            else:
-                # Prefix or exact match
-                prefix = full_pattern.name
-                files = sorted(f for f in parent.glob(f"{prefix}*") if f.is_file()) if parent.exists() else []
+        if str(rule_pattern).endswith("/"):
+            # Explicit directory pattern: only glob if the directory actually exists.
+            # Previously the code fell back to globbing the parent when the dir was
+            # absent, incorrectly registering sibling files under the wrong doc_type.
+            files = sorted(full_pattern.glob("*")) if full_pattern.is_dir() else []
+        elif full_pattern.is_dir():
+            # Pattern resolved to a directory (no trailing slash but is a dir)
+            files = sorted(full_pattern.glob("*"))
         else:
-            # Directory pattern
-            files = sorted(full_pattern.glob("*")) if full_pattern.exists() else []
+            # Prefix or exact filename match inside the parent directory
+            parent = full_pattern.parent
+            prefix = full_pattern.name
+            files = sorted(f for f in parent.glob(f"{prefix}*") if f.is_file()) if parent.exists() else []
 
         for filepath in files:
             if not filepath.is_file():

--- a/src/registry.py
+++ b/src/registry.py
@@ -277,14 +277,26 @@ def query_documents(
     return [_enrich_document(conn, dict(r)) for r in rows]
 
 
+def _sanitize_fts_query(query: str) -> str:
+    """Normalise a user-supplied FTS5 query.
+
+    SQLite FTS5 tokenises hyphens as term separators and treats the fragment
+    after the hyphen as a column-qualifier prefix (column:term syntax), causing
+    an OperationalError when no column with that name exists.  Replace hyphens
+    with spaces so callers can write 'SCN-D' and get 'SCN D' sent to FTS5.
+    """
+    return query.replace("-", " ")
+
+
 def search_documents(conn: sqlite3.Connection, query: str) -> list[dict]:
     """Full-text search across documents using FTS5. Returns matching documents."""
+    safe_query = _sanitize_fts_query(query)
     rows = conn.execute(
         """SELECT d.* FROM document d
            JOIN document_fts ON document_fts.rowid = d.rowid
            WHERE document_fts MATCH ?
            ORDER BY rank""",
-        (query,),
+        (safe_query,),
     ).fetchall()
     return [_enrich_document(conn, dict(r)) for r in rows]
 


### PR DESCRIPTION
Closes #1

## Summary

Four bugs found and fixed during `ai-dev-governance` integration testing.

### FTS5 bugs

- **Contentless FTS5 breaks update/delete** — all three virtual tables (`claim_fts`, `entity_fts`, `document_fts`) were declared with `content = ''`. SQLite contentless FTS5 tables prohibit `DELETE`, making the `_update` and `_delete` triggers permanently broken. Removed `content = ''` from all three so standard FTS5 stores its own index and `DELETE` works.

- **Hyphen in `--fts` query crashes with `OperationalError` (closes #1)** — FTS5 tokenises hyphens as term separators and treats the trailing fragment as a column-qualifier (`column:term`), so `--fts "SCN-D"` sent `D` to FTS5 as a column name and crashed. Added `_sanitize_fts_query()` in `registry.py` that replaces hyphens with spaces before the query reaches SQLite.

### `ai_dev_governance` collection scan bugs

- **Directory pattern falls back to parent glob when dir missing** — a rule like `("docs/planning/scenarios/", "gherkin")` where `scenarios/` doesn't exist caused the code to glob the parent directory instead, registering all sibling files under the wrong `doc_type`. Fixed to skip the rule when the target directory does not exist.

- **Wrong path and missing board rules** — `docs/plan/implementation-plan.md` corrected to `docs/planning/`; added `board-composition-approval-` → `board-decision` and `committee-opportunity-register-` → `board-packet`; added `bundle_type` to `COLLECTION_CONFIG` tag_keys.

## Test plan

- [ ] `--fts "SCN-D"` returns 0 results instead of crashing
- [ ] `--fts "Phase"` still returns expected documents
- [ ] UPDATE on a document row no longer raises `cannot DELETE from contentless fts5 table`
- [ ] `scan --root <repo>` with a missing `scenarios/` dir does not register sibling files as `gherkin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)