### PR TITLE
fix(fts): strip all FTS5 special chars from query input

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "astaire"
-version = "0.2.0"
+version = "0.2.2"
 description = "Hybrid memory palace — structured knowledge store for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/registry.py
+++ b/src/registry.py
@@ -280,12 +280,15 @@ def query_documents(
 def _sanitize_fts_query(query: str) -> str:
     """Normalise a user-supplied FTS5 query.
 
-    SQLite FTS5 tokenises hyphens as term separators and treats the fragment
-    after the hyphen as a column-qualifier prefix (column:term syntax), causing
-    an OperationalError when no column with that name exists.  Replace hyphens
-    with spaces so callers can write 'SCN-D' and get 'SCN D' sent to FTS5.
+    FTS5 treats many punctuation characters as syntax: hyphens become
+    column-qualifier prefixes, periods/colons/asterisks/carets trigger
+    phrase or column operators, and unmatched parens/quotes cause parse
+    errors.  Replace every non-alphanumeric, non-whitespace character
+    with a space so callers can pass raw identifiers like 'SCN-3.2'
+    without triggering FTS5 syntax errors.
     """
-    return query.replace("-", " ")
+    import re
+    return re.sub(r"[^\w\s]", " ", query)
 
 
 def search_documents(conn: sqlite3.Connection, query: str) -> list[dict]:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "astaire"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "tiktoken" },


### PR DESCRIPTION
## Summary

- `_sanitize_fts_query` previously only replaced hyphens with spaces
- Periods, colons, asterisks, carets, parens, and quotes also trigger FTS5 parse errors
- Replaced piecemeal `.replace()` calls with `re.sub(r"[^\w\s]", " ", query)` — strips all non-alphanumeric, non-whitespace characters before passing to `MATCH`

**Reproducer:** `.astaire/astaire query --fts "SCN-3.2"` → `fts5: syntax error near "."` (hyphen was sanitized, period was not)

## Test plan

- [ ] `astaire query --fts "SCN-3.2"` returns results (no crash)
- [ ] `astaire query --fts "SCN-3.3"` returns results (no crash)
- [ ] `astaire query --fts "chunk:1.2 (test)"` returns results (no crash)
- [ ] Plain keyword queries still work: `astaire query --fts "graphify"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)