### PR TITLE
Fix scan coverage for nested chunks and board docs

### DIFF
--- a/src/collections/ai_dev_governance.py
+++ b/src/collections/ai_dev_governance.py
@@ -133,13 +133,12 @@ def scan_and_register(
         full_pattern = root / rule_pattern
 
         if str(rule_pattern).endswith("/"):
-            # Explicit directory pattern: only glob if the directory actually exists.
-            # Previously the code fell back to globbing the parent when the dir was
-            # absent, incorrectly registering sibling files under the wrong doc_type.
-            files = sorted(full_pattern.glob("*")) if full_pattern.is_dir() else []
+            # Explicit directory patterns should recurse so nested chunk trees and
+            # board/member directories are discoverable in downstream repos.
+            files = _glob_dir_recursive(full_pattern)
         elif full_pattern.is_dir():
-            # Pattern resolved to a directory (no trailing slash but is a dir)
-            files = sorted(full_pattern.glob("*"))
+            # Pattern resolved to a directory (no trailing slash but is a dir).
+            files = _glob_dir_recursive(full_pattern)
         else:
             # Prefix or exact filename match inside the parent directory
             parent = full_pattern.parent
@@ -179,8 +178,66 @@ def scan_and_register(
                 "title": title,
             })
 
+    for filepath, doc_type, base_tags in _scan_governance_board(root):
+        path_str = str(filepath)
+        if path_str in existing_paths:
+            continue
+
+        tags = dict(base_tags)
+        external_id = _extract_external_id(filepath, doc_type)
+        _extract_phase_chunk_tags(filepath, tags)
+        title = _derive_title(filepath, doc_type)
+
+        doc_id = register_document(
+            conn,
+            COLLECTION_NAME,
+            filepath,
+            doc_type,
+            title,
+            tags=tags if tags else None,
+            external_id=external_id,
+            status="active",
+        )
+        existing_paths.add(path_str)
+        registered.append({
+            "document_id": doc_id,
+            "file_path": path_str,
+            "doc_type": doc_type,
+            "title": title,
+        })
+
     logger.info("Scanned and registered %d new documents in %s", len(registered), COLLECTION_NAME)
     return registered
+
+
+def _glob_dir_recursive(directory: Path) -> list[Path]:
+    """Return all files under a directory, excluding hidden paths."""
+    if not directory.is_dir():
+        return []
+    return sorted(
+        f for f in directory.rglob("*")
+        if f.is_file() and not any(part.startswith(".") for part in f.parts)
+    )
+
+
+def _scan_governance_board(root: Path) -> list[tuple[Path, str, dict[str, str]]]:
+    """Classify project board artifacts under docs/governance/board."""
+    board_dir = root / "docs" / "governance" / "board"
+    if not board_dir.is_dir():
+        return []
+
+    staged_files: list[tuple[Path, str, dict[str, str]]] = []
+    for filepath in _glob_dir_recursive(board_dir):
+        name = filepath.stem
+        if name.endswith("meeting-minutes"):
+            staged_files.append((filepath, "meeting-record", {"stage_produced": "board-review"}))
+        elif name.endswith("review-packet"):
+            staged_files.append((filepath, "board-packet", {"stage_produced": "board-review"}))
+        elif name.endswith("followup-note") or name.endswith("decision-note") or name.endswith("note"):
+            staged_files.append((filepath, "board-decision", {"stage_produced": "board-review"}))
+        elif name.endswith("memo") or "handoff-memo" in name:
+            staged_files.append((filepath, "implementation-handoff", {"stage_produced": "board-review"}))
+    return staged_files
 
 
 def _extract_external_id(filepath: Path, doc_type: str) -> str | None:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -54,6 +54,9 @@ class TestScanAndRegister:
         chunk_dir.mkdir(parents=True)
         (chunk_dir / "chunk-1.1-utils.md").write_text("# Chunk 1.1\n")
         (chunk_dir / "chunk-1.3-registry.md").write_text("# Chunk 1.3\n")
+        nested_chunk_dir = chunk_dir / "phase-7"
+        nested_chunk_dir.mkdir()
+        (nested_chunk_dir / "chunk-7.1.11b-two-lane-provisioning-contract.md").write_text("# Nested Chunk\n")
 
         # Sign-offs and traceability
         plan_dir = tmp_path / "docs" / "planning"
@@ -73,6 +76,13 @@ class TestScanAndRegister:
         members_dir.mkdir()
         (members_dir / "BM-001.md").write_text("# Martin Kleppmann\n")
         (members_dir / "BM-007.md").write_text("# Andrej Karpathy\n")
+
+        governance_board_dir = tmp_path / "docs" / "governance" / "board"
+        governance_board_dir.mkdir(parents=True)
+        (governance_board_dir / "2026-04-17-phase7-secure-transport-and-phase-posture-meeting-minutes.md").write_text("# Minutes\n")
+        (governance_board_dir / "2026-04-17-phase7-secure-transport-and-phase-posture-review-packet.md").write_text("# Packet\n")
+        (governance_board_dir / "2026-04-19-phase7-cockpitvm-startup-host-loop-followup-note.md").write_text("# Note\n")
+        (governance_board_dir / "2026-04-23-phase7-1-11b-iam-ca-posture-and-provisioning-input-memo.md").write_text("# Memo\n")
 
         # Implementation plan
         impl_dir = tmp_path / "docs" / "plan"
@@ -97,7 +107,7 @@ class TestScanAndRegister:
         assert len(gherkins) == 2
 
         chunks = query_documents(db_conn, collection_name=COLLECTION_NAME, doc_type="chunk-plan")
-        assert len(chunks) == 2
+        assert len(chunks) == 3
 
         manifests = query_documents(db_conn, collection_name=COLLECTION_NAME, doc_type="governance-manifest")
         assert len(manifests) == 1
@@ -122,6 +132,7 @@ class TestScanAndRegister:
                 chunk_tags.update(doc["tags"]["chunk"])
         assert "1.1" in chunk_tags
         assert "1.3" in chunk_tags
+        assert "7.1" in chunk_tags
 
     def test_scan_extracts_phase_tags(self, db_conn, gov_tree):
         register_ai_dev_governance(db_conn)
@@ -157,3 +168,30 @@ class TestScanAndRegister:
         ext_ids = {d["external_id"] for d in profiles}
         assert "BM-001" in ext_ids
         assert "BM-007" in ext_ids
+
+    def test_scan_registers_nested_chunk_plan(self, db_conn, gov_tree):
+        register_ai_dev_governance(db_conn)
+        scan_and_register(db_conn, gov_tree)
+
+        docs = query_documents(db_conn, collection_name=COLLECTION_NAME, doc_type="chunk-plan")
+        titles = {d["title"] for d in docs}
+        assert "Chunk 7.1.11b Two Lane Provisioning Contract" in titles
+
+    def test_scan_registers_governance_board_artifacts(self, db_conn, gov_tree):
+        register_ai_dev_governance(db_conn)
+        scan_and_register(db_conn, gov_tree)
+
+        packets = query_documents(db_conn, collection_name=COLLECTION_NAME, doc_type="board-packet")
+        meetings = query_documents(db_conn, collection_name=COLLECTION_NAME, doc_type="meeting-record")
+        decisions = query_documents(db_conn, collection_name=COLLECTION_NAME, doc_type="board-decision")
+        handoffs = query_documents(db_conn, collection_name=COLLECTION_NAME, doc_type="implementation-handoff")
+
+        packet_titles = {d["title"] for d in packets}
+        meeting_titles = {d["title"] for d in meetings}
+        decision_titles = {d["title"] for d in decisions}
+        handoff_titles = {d["title"] for d in handoffs}
+
+        assert "2026 04 17 Phase7 Secure Transport And Phase Posture Review Packet" in packet_titles
+        assert "2026 04 17 Phase7 Secure Transport And Phase Posture Meeting Minutes" in meeting_titles
+        assert "2026 04 19 Phase7 Cockpitvm Startup Host Loop Followup Note" in decision_titles
+        assert "2026 04 23 Phase7 1 11b Iam Ca Posture And Provisioning Input Memo" in handoff_titles


### PR DESCRIPTION
## Summary
- make ai-dev-governance directory scan rules recurse so nested chunk plans under docs/planning/chunks/phase-* are discovered
- add explicit classification for docs/governance/board artifacts including meeting minutes, review packets, follow-up notes, and memos
- extend collection tests to cover nested chunk plans and governance board artifacts

## Verification
- live downstream repro in CockpitVM: after patch, Astaire registered and retrieved:
  - docs/planning/chunks/phase-7/chunk-7.1.11b-two-lane-provisioning-contract.md
  - docs/governance/board/2026-04-23-phase7-1-11b-iam-ca-posture-and-provisioning-input-memo.md
- targeted Astaire FTS queries returned both documents after startup/scan

## Context
This addresses cms-pm/ai-dev-governance#16 at the tool level in the Astaire repo.