### PR TITLE
Add doctor and offline tokenizer fallback

### DIFF
--- a/.astaire/.gitignore
+++ b/.astaire/.gitignore
@@ -1,0 +1,2 @@
+.uv-cache/
+.venv/

--- a/.astaire/uv
+++ b/.astaire/uv
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${ROOT}/.astaire/.uv-cache}"
+export UV_PROJECT_ENVIRONMENT="${UV_PROJECT_ENVIRONMENT:-${ROOT}/.venv}"
+
+mkdir -p "${UV_CACHE_DIR}"
+
+exec uv "$@"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -559,7 +559,7 @@ This project uses **uv** for dependency management and virtual environment.
 
 **Rules:**
 
-- **Always use `uv run`** to execute Python commands: `uv run pytest`, `uv run python -m src.registry`, etc. This ensures the `.venv` is active and dependencies are resolved. Never call bare `python` or `python3`.
+- **Always use `./.astaire/uv run`** to execute Python commands: `./.astaire/uv run pytest`, `./.astaire/uv run python -m src.registry`, etc. This keeps the cache under `.astaire/.uv-cache`, ensures the `.venv` is active, and avoids writes to `~/.cache/uv`. Never call bare `python` or `python3`.
 - **Adding dependencies:** `uv add <package>` for runtime deps, `uv add --dev <package>` for dev/test deps.
 - **Lock file:** `uv.lock` is checked into git. Run `uv sync` if it's out of date.
 - **Python version:** 3.11+ (pinned in `pyproject.toml`).
@@ -619,7 +619,7 @@ Astaire is **single-writer by design**. SQLite WAL mode allows concurrent reads 
 **Manual fallback** (if hooks are disabled or for debugging):
 
 ```bash
-uv run astaire startup --root .
+./.astaire/uv run astaire startup --root .
 ```
 
 This single command does:
@@ -635,18 +635,19 @@ This single command does:
 
 | Command | Purpose |
 |---|---|
-| `uv run astaire startup` | Full session startup checklist |
-| `uv run astaire status` | Print L0 summary |
-| `uv run astaire scan` | Register new collection artifacts |
-| `uv run astaire sync` | Detect file drift |
-| `uv run astaire query -c my-collection -t spec` | Query by collection/type |
-| `uv run astaire query --tag chunk=1.2` | Query by tag |
-| `uv run astaire query --fts "keyword"` | Full-text search |
-| `uv run astaire context --tag chunk=1.2` | Assemble context for LLM |
-| `uv run astaire lint --fix` | Health checks with auto-fix |
-| `uv run astaire export` | Generate wiki |
-| `uv run astaire prune` | Remove expired claims |
-| `uv run astaire ingest FILE --title "..."` | Ingest a source document |
+| `./.astaire/uv run astaire startup` | Full session startup checklist |
+| `./.astaire/uv run astaire doctor` | Check DB/schema/tokenizer readiness |
+| `./.astaire/uv run astaire status` | Print L0 summary |
+| `./.astaire/uv run astaire scan` | Register new collection artifacts |
+| `./.astaire/uv run astaire sync` | Detect file drift |
+| `./.astaire/uv run astaire query -c my-collection -t spec` | Query by collection/type |
+| `./.astaire/uv run astaire query --tag chunk=1.2` | Query by tag |
+| `./.astaire/uv run astaire query --fts "keyword"` | Full-text search |
+| `./.astaire/uv run astaire context --tag chunk=1.2` | Assemble context for LLM |
+| `./.astaire/uv run astaire lint --fix` | Health checks with auto-fix |
+| `./.astaire/uv run astaire export` | Generate wiki |
+| `./.astaire/uv run astaire prune` | Remove expired claims |
+| `./.astaire/uv run astaire ingest FILE --title "..."` | Ingest a source document |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,50 +18,57 @@ These are measured results from the `ai-dev-governance` dogfood workspace on `v0
 ```bash
 git clone <repo-url> astaire
 cd astaire
-uv sync
+./.astaire/uv sync
 ```
 
 Requirements: Python 3.11+, [uv](https://docs.astral.sh/uv/).
+
+Astaire keeps its `uv` cache inside the repo by default. Use `./.astaire/uv ...`
+for local development so cache and bootstrap writes stay under `.astaire/.uv-cache`
+instead of `~/.cache/uv`.
 
 ## Quick Start
 
 ```bash
 # Initialize the database
-uv run astaire init
+./.astaire/uv run astaire init
 
 # Scan and register collection artifacts
-uv run astaire scan --root .
+./.astaire/uv run astaire scan --root .
 
 # Session startup (init + scan + sync + status)
-uv run astaire startup --root .
+./.astaire/uv run astaire startup --root .
+
+# Doctor catches bootstrap/runtime readiness issues
+./.astaire/uv run astaire doctor
 
 # Query documents by collection, type, or tag
-uv run astaire query -c my-collection
-uv run astaire query -t gherkin
-uv run astaire query --tag phase=1
+./.astaire/uv run astaire query -c my-collection
+./.astaire/uv run astaire query -t gherkin
+./.astaire/uv run astaire query --tag phase=1
 
 # Full-text search
-uv run astaire query --fts "keyword"
+./.astaire/uv run astaire query --fts "keyword"
 
 # Assemble context for LLM consumption (with token budget)
-uv run astaire context -c my-collection --budget 4000
-uv run astaire context --tag chunk=1.2
+./.astaire/uv run astaire context -c my-collection --budget 4000
+./.astaire/uv run astaire context --tag chunk=1.2
 
 # Health checks
-uv run astaire lint
-uv run astaire lint --fix
+./.astaire/uv run astaire lint
+./.astaire/uv run astaire lint --fix
 
 # Export wiki (Obsidian-compatible markdown)
-uv run astaire export
+./.astaire/uv run astaire export
 
 # Prune expired claims
-uv run astaire prune
+./.astaire/uv run astaire prune
 
 # Detect file drift
-uv run astaire sync
+./.astaire/uv run astaire sync
 
 # Ingest a source document with claims
-uv run astaire ingest raw/article.md --title "Article Title"
+./.astaire/uv run astaire ingest raw/article.md --title "Article Title"
 ```
 
 ## Architecture
@@ -151,13 +158,13 @@ All commands accept `--db PATH` to use a non-default database and `-v` for verbo
 ### Running
 
 ```bash
-uv run python -m benchmarks.bench_context --db db/memory_palace.db --root .
+./.astaire/uv run python -m benchmarks.bench_context --db db/memory_palace.db --root .
 ```
 
 In restricted or sandboxed environments, set a writable `uv` cache explicitly:
 
 ```bash
-UV_CACHE_DIR=/tmp/uvcache uv run --project astaire python -m benchmarks.bench_context --db .astaire/memory_palace.db --root .
+./.astaire/uv run --project astaire python -m benchmarks.bench_context --db .astaire/memory_palace.db --root .
 ```
 
 ### Results
@@ -188,13 +195,13 @@ The raw-FS baseline intentionally mimics what a naive agent would do: glob for p
 
 ```bash
 # Run tests
-uv run pytest
+./.astaire/uv run pytest
 
 # Run with verbose output
-uv run pytest -v
+./.astaire/uv run pytest -v
 
 # Run specific module tests
-uv run pytest tests/test_registry.py
+./.astaire/uv run pytest tests/test_registry.py
 ```
 
 ## License

--- a/src/cli.py
+++ b/src/cli.py
@@ -45,6 +45,60 @@ def cmd_status(args: argparse.Namespace) -> None:
         print(l0)
 
 
+def cmd_doctor(args: argparse.Namespace) -> None:
+    """Check runtime readiness and common failure modes."""
+    from src.utils import tokens
+
+    db_target = Path(args.db).resolve() if args.db else DB_PATH
+    db_dir = db_target.parent
+    failures = 0
+
+    if db_dir.exists():
+        print(f"[PASS] Database directory exists: {db_dir}")
+    else:
+        print(f"[FAIL] Database directory missing: {db_dir}")
+        failures += 1
+
+    schema_ok = False
+    try:
+        with managed_connection(args.db) as conn:
+            required_tables = {"collection", "document", "entity", "source", "claim"}
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+            present = {row[0] for row in rows}
+            missing = sorted(required_tables - present)
+            schema_ok = not missing
+            if schema_ok:
+                print("[PASS] Database schema initialized")
+            else:
+                print("[WARN] Database schema incomplete or not initialized")
+                print("       Run 'astaire init' or 'astaire startup' to create the schema.")
+    except SystemExit as exc:
+        print(str(exc))
+        failures += 1
+    except sqlite3.Error as exc:
+        print(f"[FAIL] Database connection failed: {exc}")
+        failures += 1
+
+    tokenizer = tokens.check_tokenizer_health()
+    if tokenizer["ok"]:
+        print(f"[PASS] {tokenizer['message']}")
+    else:
+        status = "WARN" if tokenizer["approx_tokens_enabled"] else "FAIL"
+        print(f"[{status}] {tokenizer['message']}")
+        if tokenizer["approx_tokens_enabled"]:
+            print("       Approximate token fallback is enabled; exact ingest budgets are degraded.")
+        else:
+            failures += 1
+
+    approx_state = "enabled" if tokenizer["approx_tokens_enabled"] else "disabled"
+    print(f"[INFO] Approximate token fallback: {approx_state}")
+
+    if failures:
+        raise SystemExit(1)
+
+
 def cmd_scan(args: argparse.Namespace) -> None:
     """Scan and register collection artifacts."""
     from src.collections.discovery import (
@@ -354,6 +408,9 @@ def build_parser() -> argparse.ArgumentParser:
     # status
     sub.add_parser("status", help="Show knowledge base status")
 
+    # doctor
+    sub.add_parser("doctor", help="Check runtime readiness and common failure causes")
+
     # scan
     p_scan = sub.add_parser("scan", help="Scan and register collection artifacts")
     p_scan.add_argument("--root", default=".", help="Project root directory")
@@ -427,6 +484,7 @@ def main() -> None:
         "init": cmd_init,
         "startup": cmd_startup,
         "status": cmd_status,
+        "doctor": cmd_doctor,
         "scan": cmd_scan,
         "query": cmd_query,
         "context": cmd_context,

--- a/src/utils/tokens.py
+++ b/src/utils/tokens.py
@@ -1,17 +1,97 @@
-"""Token counting via tiktoken. The only external dependency."""
+"""Token counting utilities backed by tiktoken."""
+
+from __future__ import annotations
+
+import os
 
 import tiktoken
 
 
-def count_tokens(text: str, encoding: str = "cl100k_base") -> int:
+APPROX_CHARS_PER_TOKEN = 4
+
+
+class TokenizerUnavailable(RuntimeError):
+    """Raised when the requested tokenizer encoding is unavailable."""
+
+
+def _allow_approx_tokens() -> bool:
+    value = os.getenv("ASTAIRE_ALLOW_APPROX_TOKENS", "1").strip().lower()
+    return value not in {"0", "false", "no", "off"}
+
+
+def _approx_count_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return max(1, (len(text) + APPROX_CHARS_PER_TOKEN - 1) // APPROX_CHARS_PER_TOKEN)
+
+
+def _approx_truncate(text: str, budget: int) -> str:
+    if budget <= 0 or not text:
+        return ""
+    max_chars = budget * APPROX_CHARS_PER_TOKEN
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars]
+
+
+def get_encoder(encoding: str = "cl100k_base"):
+    """Return a tiktoken encoder or raise a deterministic readiness error."""
+    try:
+        return tiktoken.get_encoding(encoding)
+    except Exception as exc:  # pragma: no cover - exercised via monkeypatch/tests
+        raise TokenizerUnavailable(
+            f"Tokenizer encoding '{encoding}' is unavailable. "
+            "Run Astaire bootstrap/doctor while online to prewarm tokenizer assets."
+        ) from exc
+
+
+def check_tokenizer_health(encoding: str = "cl100k_base") -> dict[str, str | bool]:
+    """Report whether the tokenizer encoding is ready for exact token counts."""
+    try:
+        get_encoder(encoding)
+    except TokenizerUnavailable as exc:
+        return {
+            "ok": False,
+            "encoding": encoding,
+            "message": str(exc),
+            "approx_tokens_enabled": _allow_approx_tokens(),
+        }
+    return {
+        "ok": True,
+        "encoding": encoding,
+        "message": f"Tokenizer encoding '{encoding}' is ready.",
+        "approx_tokens_enabled": _allow_approx_tokens(),
+    }
+
+
+def count_tokens(text: str, encoding: str = "cl100k_base", allow_approx: bool | None = None) -> int:
     """Count tokens in text using the specified tiktoken encoding."""
-    enc = tiktoken.get_encoding(encoding)
+    if allow_approx is None:
+        allow_approx = _allow_approx_tokens()
+    try:
+        enc = get_encoder(encoding)
+    except TokenizerUnavailable:
+        if allow_approx:
+            return _approx_count_tokens(text)
+        raise
     return len(enc.encode(text))
 
 
-def truncate_to_budget(text: str, budget: int, encoding: str = "cl100k_base") -> str:
+def truncate_to_budget(
+    text: str,
+    budget: int,
+    encoding: str = "cl100k_base",
+    allow_approx: bool | None = None,
+) -> str:
     """Truncate text to fit within a token budget, preserving whole tokens."""
-    enc = tiktoken.get_encoding(encoding)
+    if allow_approx is None:
+        allow_approx = _allow_approx_tokens()
+    try:
+        enc = get_encoder(encoding)
+    except TokenizerUnavailable:
+        if allow_approx:
+            return _approx_truncate(text, budget)
+        raise
     tokens = enc.encode(text)
     if len(tokens) <= budget:
         return text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ import pytest
 
 from src.cli import (
     cmd_context,
+    cmd_doctor,
     cmd_export,
     cmd_graphify_import,
     cmd_init,
@@ -210,6 +211,70 @@ class TestStatus:
         ).fetchone()["content_hash"]
         conn.close()
         assert fresh_hash != "stale-hash"
+
+
+class TestDoctor:
+    def test_doctor_reports_healthy_runtime(self, tmp_db, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "src.utils.tokens.check_tokenizer_health",
+            lambda encoding="cl100k_base": {
+                "ok": True,
+                "encoding": encoding,
+                "message": f"Tokenizer encoding '{encoding}' is ready.",
+                "approx_tokens_enabled": True,
+            },
+        )
+        cmd_doctor(_args(db=tmp_db))
+        out = capsys.readouterr().out
+        assert "[PASS] Database schema initialized" in out
+        assert "[PASS] Tokenizer encoding 'cl100k_base' is ready." in out
+
+    def test_doctor_reports_missing_schema_as_warning(self, tmp_path, monkeypatch, capsys):
+        db_path = str(tmp_path / "empty.db")
+        Path(db_path).touch()
+        monkeypatch.setattr(
+            "src.utils.tokens.check_tokenizer_health",
+            lambda encoding="cl100k_base": {
+                "ok": True,
+                "encoding": encoding,
+                "message": f"Tokenizer encoding '{encoding}' is ready.",
+                "approx_tokens_enabled": True,
+            },
+        )
+        cmd_doctor(_args(db=db_path))
+        out = capsys.readouterr().out
+        assert "[WARN] Database schema incomplete or not initialized" in out
+
+    def test_doctor_fails_when_database_directory_missing(self, tmp_path, monkeypatch, capsys):
+        db_path = str(tmp_path / "missing" / "doctor.db")
+        monkeypatch.setattr(
+            "src.utils.tokens.check_tokenizer_health",
+            lambda encoding="cl100k_base": {
+                "ok": True,
+                "encoding": encoding,
+                "message": f"Tokenizer encoding '{encoding}' is ready.",
+                "approx_tokens_enabled": True,
+            },
+        )
+        with pytest.raises(SystemExit):
+            cmd_doctor(_args(db=db_path))
+        out = capsys.readouterr().out
+        assert "[FAIL] Database directory missing" in out
+
+    def test_doctor_warns_when_tokenizer_falls_back(self, tmp_db, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "src.utils.tokens.check_tokenizer_health",
+            lambda encoding="cl100k_base": {
+                "ok": False,
+                "encoding": encoding,
+                "message": "Tokenizer encoding 'cl100k_base' is unavailable.",
+                "approx_tokens_enabled": True,
+            },
+        )
+        cmd_doctor(_args(db=tmp_db))
+        out = capsys.readouterr().out
+        assert "[WARN] Tokenizer encoding 'cl100k_base' is unavailable." in out
+        assert "Approximate token fallback is enabled" in out
 
 
 # ── Scan ─────────────────────────────────────────────────────────
@@ -791,3 +856,14 @@ class TestConnectionCleanup:
         ).fetchall()]
         assert "entity" in tables
         conn2.close()
+
+
+class TestCLIParser:
+    def test_parser_shows_help_for_missing_command(self):
+        parser = build_parser()
+        assert parser.parse_args([]).command is None
+
+    def test_parser_accepts_doctor(self):
+        parser = build_parser()
+        args = parser.parse_args(["doctor"])
+        assert args.command == "doctor"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,8 @@
 import time
 from pathlib import Path
 
+import pytest
+
 from src.utils import hashing, ulid, tokens
 
 
@@ -90,3 +92,25 @@ class TestTokens:
         result = tokens.truncate_to_budget(text, budget=20)
         assert len(result) > 0
         assert isinstance(result, str)
+
+    def test_count_tokens_falls_back_when_tokenizer_unavailable(self, monkeypatch):
+        monkeypatch.setattr(tokens, "get_encoder", lambda encoding="cl100k_base": (_ for _ in ()).throw(tokens.TokenizerUnavailable("offline")))
+        count = tokens.count_tokens("abcdefgh", allow_approx=True)
+        assert count == 2
+
+    def test_truncate_falls_back_when_tokenizer_unavailable(self, monkeypatch):
+        monkeypatch.setattr(tokens, "get_encoder", lambda encoding="cl100k_base": (_ for _ in ()).throw(tokens.TokenizerUnavailable("offline")))
+        result = tokens.truncate_to_budget("abcdefghij", budget=2, allow_approx=True)
+        assert result == "abcdefgh"
+
+    def test_count_tokens_raises_when_approx_disabled(self, monkeypatch):
+        monkeypatch.setattr(tokens, "get_encoder", lambda encoding="cl100k_base": (_ for _ in ()).throw(tokens.TokenizerUnavailable("offline")))
+        with pytest.raises(tokens.TokenizerUnavailable):
+            tokens.count_tokens("abcdefgh", allow_approx=False)
+
+    def test_check_tokenizer_health_reports_unavailable(self, monkeypatch):
+        monkeypatch.setattr(tokens, "get_encoder", lambda encoding="cl100k_base": (_ for _ in ()).throw(tokens.TokenizerUnavailable("offline")))
+        health = tokens.check_tokenizer_health()
+        assert health["ok"] is False
+        assert health["approx_tokens_enabled"] is True
+        assert "offline" in health["message"]


### PR DESCRIPTION
## Summary
- add an `astaire doctor` command for DB/schema/tokenizer readiness checks
- fall back to approximate token counting/truncation when tokenizer assets are unavailable
- add tests for the new doctor command and offline tokenizer behavior

Closes #12