### PR TITLE
fix(scan): refresh modified documents alongside new registrations

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -100,18 +100,24 @@ def cmd_doctor(args: argparse.Namespace) -> None:
 
 
 def cmd_scan(args: argparse.Namespace) -> None:
-    """Scan and register collection artifacts."""
+    """Scan and register collection artifacts.
+
+    Also refreshes existing documents whose on-disk content has changed,
+    so a `scan` after editing a registered file picks up the new
+    content_hash and re-runs FTS triggers on title/external_id/doc_type
+    derivations. Pass --no-sync to disable.
+    """
     from src.collections.discovery import (
         discover_collection_modules,
         register_all_collections,
         scan_all_collections,
     )
+    from src.registry import sync_all, sync_collection
 
     with managed_connection(args.db) as conn:
         root = Path(args.root).resolve()
 
         if args.collection:
-            # Scan a specific collection only
             modules = discover_collection_modules()
             target = [m for m in modules if m.COLLECTION_NAME == args.collection]
             if not target:
@@ -120,13 +126,24 @@ def cmd_scan(args: argparse.Namespace) -> None:
             mod = target[0]
             mod.register_collection(conn)
             results = mod.scan_and_register(conn, root)
+            sync_changes = [] if args.no_sync else sync_collection(conn, args.collection)
         else:
             register_all_collections(conn)
             results = scan_all_collections(conn, root)
+            sync_changes = [] if args.no_sync else sync_all(conn)
 
         print(f"Registered {len(results)} new document(s)")
         for doc in results:
             print(f"  {doc['doc_type']:20s} {doc['title']}")
+
+        if sync_changes:
+            refreshed = [c for c in sync_changes if not c.get("missing")]
+            archived = [c for c in sync_changes if c.get("missing")]
+            print(f"Refreshed {len(refreshed)} modified document(s); archived {len(archived)} missing")
+            for c in refreshed:
+                print(f"  refreshed            {c['title']}")
+            for c in archived:
+                print(f"  archived             {c['title']}")
 
 
 def cmd_query(args: argparse.Namespace) -> None:
@@ -415,6 +432,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_scan = sub.add_parser("scan", help="Scan and register collection artifacts")
     p_scan.add_argument("--root", default=".", help="Project root directory")
     p_scan.add_argument("-c", "--collection", help="Scan only this collection")
+    p_scan.add_argument(
+        "--no-sync",
+        action="store_true",
+        help="Do not refresh existing documents whose content has changed",
+    )
 
     # query
     p_query = sub.add_parser("query", help="Query documents")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,7 +120,7 @@ def sample_project(tmp_path):
 
 def _args(**kwargs):
     """Build a Namespace with defaults."""
-    defaults = {"db": None, "verbose": False}
+    defaults = {"db": None, "verbose": False, "no_sync": False}
     defaults.update(kwargs)
     return Namespace(**defaults)
 
@@ -311,6 +311,53 @@ class TestScan:
         cmd_scan(_args(db=db_path, root=str(sample_project), collection=None))
         out = capsys.readouterr().out
         assert "Registered 0 new document(s)" in out
+
+    def test_scan_refreshes_modified_documents(self, tmp_path, sample_project, capsys):
+        """Issue #14: scan must refresh existing documents whose content has
+        changed on disk, not only register new files."""
+        db_path = str(tmp_path / "scan_refresh.db")
+        cmd_init(_args(db=db_path))
+        cmd_scan(_args(db=db_path, root=str(sample_project), collection=None))
+        capsys.readouterr()
+
+        conn = get_connection(db_path)
+        row = conn.execute("SELECT file_path, content_hash FROM document LIMIT 1").fetchone()
+        target = Path(row["file_path"])
+        old_hash = row["content_hash"]
+        conn.close()
+        assert target.exists()
+
+        original_text = target.read_text(encoding="utf-8")
+        target.write_text(original_text + "\n\n## Appended for issue #14\n", encoding="utf-8")
+
+        cmd_scan(_args(db=db_path, root=str(sample_project), collection=None))
+        out = capsys.readouterr().out
+        assert "Refreshed" in out
+
+        conn = get_connection(db_path)
+        new_hash = conn.execute(
+            "SELECT content_hash FROM document WHERE file_path = ?", (str(target),)
+        ).fetchone()["content_hash"]
+        conn.close()
+        assert new_hash != old_hash, "scan should refresh content_hash on modified files"
+
+    def test_scan_no_sync_skips_refresh(self, tmp_path, sample_project, capsys):
+        """--no-sync preserves the prior scan-only behavior for callers that
+        want to register without paying for a full-collection rehash."""
+        db_path = str(tmp_path / "scan_no_sync.db")
+        cmd_init(_args(db=db_path))
+        cmd_scan(_args(db=db_path, root=str(sample_project), collection=None))
+        capsys.readouterr()
+
+        conn = get_connection(db_path)
+        row = conn.execute("SELECT file_path FROM document LIMIT 1").fetchone()
+        target = Path(row["file_path"])
+        conn.close()
+        target.write_text(target.read_text() + "\nedit\n", encoding="utf-8")
+
+        cmd_scan(_args(db=db_path, root=str(sample_project), collection=None, no_sync=True))
+        out = capsys.readouterr().out
+        assert "Refreshed" not in out
 
 
 # ── Query ────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #14.

## Problem

\`astaire scan --root .\` only registered new files; existing documents whose content changed on disk were never refreshed. After editing a registered file, FTS queries returned stale (or empty) results because the row's \`content_hash\`, \`token_count\`, and FTS-indexed fields were never re-derived.

\`cmd_startup\` already does scan + sync, but the standalone \`scan\` command did not.

## Change

\`cmd_scan\` now calls \`sync_collection()\` (or \`sync_all()\` when no specific collection is targeted) after the register pass. Modified files have their hashes refreshed; the FTS triggers fire on \`title\` / \`external_id\` / \`doc_type\` derivations.

A new \`--no-sync\` flag preserves the prior register-only behavior for callers who want to skip the rehash pass.

## Output

\`\`\`
\$ astaire scan --root .
Registered 2 new document(s)
  chunk-plan           Chunk 8.0u Copilot Broker Lifecycle...
  validation-evidence  Phase 8 0t Fast Queue Backpressure Record
Refreshed 1 modified document(s); archived 0 missing
  refreshed            2026 04 24 Phase7 Post 7 1 12 Roadmap...
\`\`\`

## Note on FTS scope

\`document_fts\` only indexes \`title\`, \`external_id\`, and \`doc_type\` — not the document body. Queries that look for content **substrings inside the body** will still return empty even after this fix. The reporter's bug touched both gaps; this PR closes the scan-doesn't-sync half. Indexing body content is a separate, larger feature (would require schema change + regeneration cost trade-off) and is out of scope here.

## Test plan

Two new tests in \`tests/test_cli.py::TestScan\`:

- [x] \`test_scan_refreshes_modified_documents\` — register, edit a file, scan again, assert content_hash changed and 'Refreshed' appeared in output
- [x] \`test_scan_no_sync_skips_refresh\` — confirm --no-sync preserves register-only behavior

Full suite: 335 passed (333 prior + 2 new), 2 deselected (pre-existing flaky perf benchmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)