### PR TITLE
feat(#15): extend source_type taxonomy with governance-artifact types

### DIFF
--- a/docs/schema/memory_palace_schema.sql
+++ b/docs/schema/memory_palace_schema.sql
@@ -38,7 +38,12 @@ PRAGMA foreign_keys = ON;
 CREATE TABLE IF NOT EXISTS source (
     source_id     TEXT PRIMARY KEY,   -- ULID
     title         TEXT NOT NULL,
-    source_type   TEXT NOT NULL CHECK (source_type IN ('article','paper','transcript','note','code','synthesis')),
+    source_type   TEXT NOT NULL CHECK (source_type IN (
+        -- research-corpus types
+        'article','paper','transcript','note','code','synthesis',
+        -- governance-artifact types (issue #15)
+        'chunk-plan','validation','gherkin','architecture','adr','memo','contract-test'
+    )),
     content_hash  TEXT NOT NULL,       -- SHA-256 of raw content
     file_path     TEXT,                -- path to raw file on disk
     media_type    TEXT DEFAULT 'text/markdown',

--- a/src/db.py
+++ b/src/db.py
@@ -31,7 +31,67 @@ def init_db(conn: sqlite3.Connection, schema_path: str | Path | None = None) -> 
     path = Path(schema_path) if schema_path else SCHEMA_PATH
     ddl = path.read_text()
     conn.executescript(ddl)
+    migrate_source_type_taxonomy(conn)
     logger.info("Database schema initialized from %s", path)
+
+
+# Governance-artifact source_type values added in issue #15. An existing DB
+# created before this migration carries the older research-only CHECK
+# constraint and must be rebuilt before governance ingest can succeed.
+_GOVERNANCE_SOURCE_TYPES = ("chunk-plan", "validation", "gherkin", "architecture", "adr", "memo", "contract-test")
+
+
+def migrate_source_type_taxonomy(conn: sqlite3.Connection) -> bool:
+    """Extend source.source_type CHECK constraint with governance-artifact types.
+
+    Idempotent. Returns True if a rebuild ran, False if the schema was already
+    current. SQLite cannot ALTER a CHECK constraint, so when the old constraint
+    is detected we rebuild source via create-new + copy + drop + rename inside
+    a single transaction.
+    """
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='source'"
+    ).fetchone()
+    if row is None:
+        return False
+    existing_sql = row[0] or ""
+    if "'chunk-plan'" in existing_sql:
+        return False
+
+    conn.execute("BEGIN")
+    try:
+        conn.execute("""
+            CREATE TABLE source__new (
+                source_id     TEXT PRIMARY KEY,
+                title         TEXT NOT NULL,
+                source_type   TEXT NOT NULL CHECK (source_type IN (
+                    'article','paper','transcript','note','code','synthesis',
+                    'chunk-plan','validation','gherkin','architecture','adr','memo','contract-test'
+                )),
+                content_hash  TEXT NOT NULL,
+                file_path     TEXT,
+                media_type    TEXT DEFAULT 'text/markdown',
+                token_count   INTEGER DEFAULT 0,
+                ingested_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+                metadata_json TEXT DEFAULT '{}'
+            )
+        """)
+        conn.execute("""
+            INSERT INTO source__new
+                (source_id, title, source_type, content_hash, file_path,
+                 media_type, token_count, ingested_at, metadata_json)
+            SELECT source_id, title, source_type, content_hash, file_path,
+                   media_type, token_count, ingested_at, metadata_json
+            FROM source
+        """)
+        conn.execute("DROP TABLE source")
+        conn.execute("ALTER TABLE source__new RENAME TO source")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    logger.info("Migrated source.source_type CHECK constraint with governance types")
+    return True
 
 
 @contextmanager

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -2,7 +2,7 @@
 
 import sqlite3
 
-from src.db import get_connection, init_db, transaction
+from src.db import get_connection, init_db, migrate_source_type_taxonomy, transaction
 
 
 class TestConnection:
@@ -71,6 +71,97 @@ class TestInitDB:
         row = db_conn.execute("SELECT operation, documents_registered FROM ingest_log").fetchone()
         assert row["operation"] == "register"
         assert row["documents_registered"] == 1
+
+
+class TestSourceTypeTaxonomyMigration:
+    """Issue #15 — source_type CHECK constraint extension with governance types."""
+
+    _OLD_DDL = """
+        CREATE TABLE source (
+            source_id     TEXT PRIMARY KEY,
+            title         TEXT NOT NULL,
+            source_type   TEXT NOT NULL CHECK (source_type IN (
+                'article','paper','transcript','note','code','synthesis'
+            )),
+            content_hash  TEXT NOT NULL,
+            file_path     TEXT,
+            media_type    TEXT DEFAULT 'text/markdown',
+            token_count   INTEGER DEFAULT 0,
+            ingested_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+            metadata_json TEXT DEFAULT '{}'
+        )
+    """
+
+    def _legacy_db(self):
+        conn = get_connection(":memory:")
+        conn.executescript(self._OLD_DDL)
+        return conn
+
+    def test_legacy_db_rejects_governance_type_before_migration(self):
+        conn = self._legacy_db()
+        from src.utils.ulid import generate
+        try:
+            conn.execute(
+                "INSERT INTO source (source_id, title, source_type, content_hash) "
+                "VALUES (?, 'plan', 'chunk-plan', 'h')",
+                (generate(),),
+            )
+            raised = False
+        except sqlite3.IntegrityError:
+            raised = True
+        assert raised
+        conn.close()
+
+    def test_migration_rebuilds_and_preserves_rows(self):
+        conn = self._legacy_db()
+        from src.utils.ulid import generate
+
+        sid = generate()
+        conn.execute(
+            "INSERT INTO source (source_id, title, source_type, content_hash) "
+            "VALUES (?, 'note-1', 'note', 'h1')",
+            (sid,),
+        )
+        conn.commit()
+
+        ran = migrate_source_type_taxonomy(conn)
+        assert ran is True
+
+        row = conn.execute(
+            "SELECT title, source_type FROM source WHERE source_id = ?", (sid,)
+        ).fetchone()
+        assert row["title"] == "note-1"
+        assert row["source_type"] == "note"
+
+        conn.execute(
+            "INSERT INTO source (source_id, title, source_type, content_hash) "
+            "VALUES (?, 'plan', 'chunk-plan', 'h2')",
+            (generate(),),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_migration_is_idempotent(self):
+        conn = self._legacy_db()
+        assert migrate_source_type_taxonomy(conn) is True
+        assert migrate_source_type_taxonomy(conn) is False
+        conn.close()
+
+    def test_migration_noop_on_fresh_init_db(self, db_conn):
+        assert migrate_source_type_taxonomy(db_conn) is False
+
+    def test_init_db_upgrades_legacy_schema(self):
+        conn = self._legacy_db()
+        init_db(conn)
+        from src.utils.ulid import generate
+        for stype in ("chunk-plan", "validation", "gherkin", "architecture", "adr", "memo", "contract-test"):
+            conn.execute(
+                "INSERT INTO source (source_id, title, source_type, content_hash) "
+                "VALUES (?, ?, ?, ?)",
+                (generate(), f"t-{stype}", stype, "h"),
+            )
+        conn.commit()
+        conn.close()
 
 
 class TestTransaction:


### PR DESCRIPTION
Closes #15.

## Summary
- Extends `source.source_type` CHECK constraint with 7 governance-artifact types: `chunk-plan`, `validation`, `gherkin`, `architecture`, `adr`, `memo`, `contract-test`.
- Adds `migrate_source_type_taxonomy()` helper in `src/db.py` that detects the legacy constraint via `sqlite_master.sql` and rebuilds the table (create-new + copy + drop + rename) inside a single transaction. SQLite cannot ALTER a CHECK constraint.
- Wires migration into `init_db()` so existing DBs upgrade transparently on next open.
- Migration is idempotent: returns `True` on rebuild, `False` if already current.

## Why this matters
Predicate (#17) and scenario-ledger (#16) collections, plus the governance-authoring and ai-dev-governance collections, ingest non-research artifacts. Without this extension every governance ingest would fail the CHECK constraint at the claim-store boundary.

## Test plan
- [x] `pytest tests/test_db.py` — 15/15 pass, including 5 new migration tests
- [x] Full suite — 339/339 pass (one pre-existing perf test deselected)
- [x] Idempotency: second migration call returns `False`
- [x] Legacy schema upgrades cleanly via `init_db()` and accepts all 7 new types