### PR TITLE
feat(#17): add scenario-predicate collection plugin

### DIFF
--- a/src/collections/scenario_predicate.py
+++ b/src/collections/scenario_predicate.py
@@ -1,0 +1,158 @@
+"""scenario-predicates collection — indexes scn-*.json predicate files.
+
+Issue #17. Each scenario block inside a `docs/validation/**/predicates/*.json`
+file becomes one document, keyed by SCN external_id. Predicate hash is the
+SHA-256 of the canonical (sorted-keys, no whitespace) scenario JSON; it
+crosses to the scenario-ledger collection (issue #16) for evidence audit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+from pathlib import Path
+
+from src.registry import create_collection, get_collection, register_document
+
+logger = logging.getLogger(__name__)
+
+COLLECTION_NAME = "scenario-predicates"
+
+COLLECTION_CONFIG = {
+    "doc_types": ["predicate"],
+    "tag_keys": [
+        "chunk",
+        "feature",
+        "predicate_kind",
+        "haiku_eligible",
+        "schema_version",
+        "owner_chunk_plan",
+        "surface",
+    ],
+    "statuses": ["active", "superseded", "archived"],
+}
+
+PREDICATE_GLOB = "docs/validation/**/predicates/*.json"
+
+
+def register_collection(conn: sqlite3.Connection) -> str:
+    existing = get_collection(conn, COLLECTION_NAME)
+    if existing:
+        return existing["collection_id"]
+    return create_collection(
+        conn,
+        COLLECTION_NAME,
+        "Per-scenario predicate definitions for HiL/SiL routing",
+        COLLECTION_CONFIG,
+    )
+
+
+def scan_and_register(
+    conn: sqlite3.Connection,
+    root_dir: str | Path,
+) -> list[dict]:
+    root = Path(root_dir)
+    col = get_collection(conn, COLLECTION_NAME)
+    if col is None:
+        raise ValueError(
+            f"Collection {COLLECTION_NAME!r} not registered. "
+            "Call register_collection() first."
+        )
+
+    existing_ext_ids: set[str] = set()
+    for row in conn.execute(
+        "SELECT external_id FROM document "
+        "WHERE collection_id = ? AND external_id IS NOT NULL",
+        (col["collection_id"],),
+    ).fetchall():
+        existing_ext_ids.add(row["external_id"])
+
+    registered: list[dict] = []
+    for predicate_path in sorted(root.glob(PREDICATE_GLOB)):
+        if not predicate_path.is_file():
+            continue
+        try:
+            payload = json.loads(predicate_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("skip predicate file %s: %s", predicate_path, exc)
+            continue
+
+        scenarios = payload.get("scenarios")
+        if not isinstance(scenarios, dict):
+            logger.warning("skip %s: missing scenarios object", predicate_path)
+            continue
+
+        chunk = str(payload.get("chunk", "")).strip()
+        feature = str(payload.get("feature", "")).strip()
+        owner_plan = str(payload.get("owner_chunk_plan", "")).strip()
+        schema_version = str(payload.get("schema_version", "")).strip()
+        routing = payload.get("routing_hint") or {}
+        haiku_eligible = set(routing.get("haiku_eligible") or [])
+
+        for scn_id, scn_block in scenarios.items():
+            if not isinstance(scn_block, dict):
+                continue
+            if scn_id in existing_ext_ids:
+                continue
+
+            phash = _predicate_hash(scn_block)
+            tags: dict[str, str | list[str]] = {}
+            if chunk:
+                tags["chunk"] = chunk
+            if feature:
+                tags["feature"] = feature
+            if schema_version:
+                tags["schema_version"] = schema_version
+            if owner_plan:
+                tags["owner_chunk_plan"] = owner_plan
+            kind = scn_block.get("predicate_kind")
+            if kind:
+                tags["predicate_kind"] = str(kind)
+            surface = scn_block.get("surface")
+            if surface:
+                tags["surface"] = str(surface)
+            tags["haiku_eligible"] = "true" if scn_id in haiku_eligible else "false"
+
+            metadata = {
+                "scenario_id": scn_id,
+                "predicate_hash": phash,
+                "scenario": scn_block,
+                "predicate_file": str(predicate_path),
+            }
+            title = str(scn_block.get("intent") or scn_id)
+
+            doc_id = register_document(
+                conn,
+                COLLECTION_NAME,
+                predicate_path,
+                "predicate",
+                title,
+                tags=tags,
+                external_id=scn_id,
+                metadata=metadata,
+                status="active",
+            )
+            existing_ext_ids.add(scn_id)
+            registered.append(
+                {
+                    "document_id": doc_id,
+                    "scenario_id": scn_id,
+                    "predicate_hash": phash,
+                    "file_path": str(predicate_path),
+                }
+            )
+
+    logger.info(
+        "Scanned and registered %d new scenarios in %s",
+        len(registered),
+        COLLECTION_NAME,
+    )
+    return registered
+
+
+def _predicate_hash(scenario_block: dict) -> str:
+    """SHA-256 of canonical (sorted-keys, no whitespace) scenario JSON."""
+    canonical = json.dumps(scenario_block, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/tests/test_scenario_predicate.py
+++ b/tests/test_scenario_predicate.py
@@ -1,0 +1,143 @@
+"""Tests for src/collections/scenario_predicate (issue #17)."""
+
+import hashlib
+import json
+
+from src.collections.scenario_predicate import (
+    COLLECTION_NAME,
+    _predicate_hash,
+    register_collection,
+    scan_and_register,
+)
+from src.registry import get_collection, query_documents
+
+
+def _write_predicate(tmp_path, chunk: str, scenarios: dict, routing=None):
+    pred_dir = tmp_path / "docs" / "validation" / f"phase-{chunk[0]}" / "predicates"
+    pred_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "chunk": chunk,
+        "feature": f"feat-{chunk}",
+        "owner_chunk_plan": f"docs/planning/chunks/phase-{chunk[0]}/chunk-{chunk}.md",
+        "schema_version": "0.1.0-pilot",
+        "scenarios": scenarios,
+    }
+    if routing is not None:
+        payload["routing_hint"] = routing
+    path = pred_dir / f"scn-{chunk}.json"
+    path.write_text(json.dumps(payload))
+    return path
+
+
+class TestRegisterCollection:
+    def test_creates_collection(self, db_conn):
+        cid = register_collection(db_conn)
+        assert len(cid) == 26
+        col = get_collection(db_conn, COLLECTION_NAME)
+        assert col is not None
+        assert col["name"] == COLLECTION_NAME
+
+    def test_idempotent(self, db_conn):
+        cid1 = register_collection(db_conn)
+        cid2 = register_collection(db_conn)
+        assert cid1 == cid2
+
+
+class TestPredicateHash:
+    def test_canonical_and_stable(self):
+        a = {"predicate_kind": "queue_depth_at_least", "minimum_depth": 16}
+        b = {"minimum_depth": 16, "predicate_kind": "queue_depth_at_least"}
+        assert _predicate_hash(a) == _predicate_hash(b)
+
+    def test_changes_with_content(self):
+        a = {"predicate_kind": "queue_depth_at_least", "minimum_depth": 16}
+        b = {"predicate_kind": "queue_depth_at_least", "minimum_depth": 32}
+        assert _predicate_hash(a) != _predicate_hash(b)
+
+    def test_known_hash(self):
+        block = {"predicate_kind": "noop"}
+        canonical = '{"predicate_kind":"noop"}'
+        expected = hashlib.sha256(canonical.encode()).hexdigest()
+        assert _predicate_hash(block) == expected
+
+
+class TestScanAndRegister:
+    def test_registers_one_row_per_scenario(self, db_conn, tmp_path):
+        _write_predicate(
+            tmp_path,
+            "8.0t",
+            {
+                "SCN-8.0t-01": {
+                    "intent": "depth bumped",
+                    "predicate_kind": "queue_depth_at_least",
+                    "surface": "src/esp32_bridge_main.c",
+                },
+                "SCN-8.0t-03": {
+                    "intent": "STATUS additive",
+                    "predicate_kind": "status_field_additive",
+                    "surface": "behavioral",
+                },
+            },
+            routing={"haiku_eligible": ["SCN-8.0t-03"]},
+        )
+        register_collection(db_conn)
+        result = scan_and_register(db_conn, tmp_path)
+        assert len(result) == 2
+
+        docs = query_documents(db_conn, collection_name=COLLECTION_NAME)
+        ext_ids = {d["external_id"] for d in docs}
+        assert ext_ids == {"SCN-8.0t-01", "SCN-8.0t-03"}
+
+    def test_idempotent_skip_existing(self, db_conn, tmp_path):
+        _write_predicate(
+            tmp_path,
+            "8.0t",
+            {"SCN-8.0t-01": {"intent": "x", "predicate_kind": "k"}},
+        )
+        register_collection(db_conn)
+        first = scan_and_register(db_conn, tmp_path)
+        second = scan_and_register(db_conn, tmp_path)
+        assert len(first) == 1
+        assert len(second) == 0
+
+    def test_haiku_eligible_tag(self, db_conn, tmp_path):
+        _write_predicate(
+            tmp_path,
+            "8.0t",
+            {
+                "SCN-A": {"intent": "a", "predicate_kind": "k"},
+                "SCN-B": {"intent": "b", "predicate_kind": "k"},
+            },
+            routing={"haiku_eligible": ["SCN-B"]},
+        )
+        register_collection(db_conn)
+        scan_and_register(db_conn, tmp_path)
+
+        rows = db_conn.execute(
+            "SELECT d.external_id, dt.tag_value "
+            "FROM document d JOIN document_tag dt USING(document_id) "
+            "WHERE dt.tag_key='haiku_eligible' ORDER BY d.external_id"
+        ).fetchall()
+        result = {r["external_id"]: r["tag_value"] for r in rows}
+        assert result == {"SCN-A": "false", "SCN-B": "true"}
+
+    def test_predicate_hash_in_metadata(self, db_conn, tmp_path):
+        block = {"intent": "x", "predicate_kind": "queue_depth_at_least"}
+        _write_predicate(tmp_path, "8.0t", {"SCN-X": block})
+        register_collection(db_conn)
+        scan_and_register(db_conn, tmp_path)
+
+        row = db_conn.execute(
+            "SELECT metadata_json FROM document WHERE external_id='SCN-X'"
+        ).fetchone()
+        meta = json.loads(row["metadata_json"])
+        assert meta["predicate_hash"] == _predicate_hash(block)
+        assert meta["scenario_id"] == "SCN-X"
+
+    def test_skips_malformed_json(self, db_conn, tmp_path):
+        pred_dir = tmp_path / "docs" / "validation" / "phase-9" / "predicates"
+        pred_dir.mkdir(parents=True)
+        (pred_dir / "scn-bad.json").write_text("{not json")
+        register_collection(db_conn)
+        result = scan_and_register(db_conn, tmp_path)
+        assert result == []


### PR DESCRIPTION
Closes #17.

## Summary
- New `src/collections/scenario_predicate.py` — discovers `docs/validation/**/predicates/*.json` and registers **one document per scenario** (`SCN-*`), keyed by `external_id`.
- Computes `predicate_hash = SHA-256(canonical_sorted_json(scenario_block))` and stores it in `metadata_json`. This is the cross-reference key the scenario-ledger collection (#16) will use to detect drift.
- Tags: `chunk`, `feature`, `predicate_kind`, `surface`, `schema_version`, `owner_chunk_plan`, `haiku_eligible`.
- Auto-discovered via the existing `src/collections/discovery.py` protocol — no wiring changes required.

## Why this matters
Predicates are the architect-tier authoring surface in the HiL/SiL Predicate Router pattern (governance PR #21). Indexing them in Astaire makes them queryable by chunk/feature/predicate_kind, and the predicate_hash gives the scenario-ledger collection a stable join key for evidence audit.

## Coordination
- Pairs with **governance PR #22** (`SCENARIO_LEDGER_RUNBOOK.md`) and **governance PR #21** (`HIL_SIL_PREDICATE_ROUTER.md`).
- Schema CHECK constraint extension (#15) is independent — predicates land in the `document` table, not the `source` claim-store table.

## Test plan
- [x] 10 new tests pass: collection registration, predicate-hash canonicality, one-row-per-SCN, idempotent re-scan, haiku_eligible tagging, malformed-JSON skip
- [x] Full suite — 349/349 pass (one pre-existing perf test deselected)