### PR TITLE
feat(#16): add scenario-ledger collection plugin

### DIFF
--- a/src/collections/scenario_ledger.py
+++ b/src/collections/scenario_ledger.py
@@ -1,0 +1,153 @@
+"""scenario-ledger collection — indexes the append-only scenario evidence ledger.
+
+Issue #16. Reads `artifacts/validation/scenario_ledger.jsonl` (JSONL, one
+record per scenario observation). Latest record per `scenario_id` wins; the
+collection exposes that current status keyed by SCN. The `predicate_hash`
+field cross-references rows in the scenario-predicates collection (#17) so
+drift between predicate definition and observed evidence becomes a join
+question.
+
+Status enum mirrors `core/EVIDENCE_CONTRACT.md` (governance PR #20):
+not-started, expected-fail, passing, failing, waived.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+
+from src.registry import create_collection, get_collection, register_document
+
+logger = logging.getLogger(__name__)
+
+COLLECTION_NAME = "scenario-ledger"
+
+LEDGER_PATH = "artifacts/validation/scenario_ledger.jsonl"
+
+ALLOWED_STATUSES = {
+    "not-started",
+    "expected-fail",
+    "passing",
+    "failing",
+    "waived",
+}
+
+COLLECTION_CONFIG = {
+    "doc_types": ["ledger-entry"],
+    "tag_keys": [
+        "scenario_id",
+        "chunk",
+        "status",
+        "predicate_hash",
+        "actor",
+        "evidence_kind",
+    ],
+    "statuses": sorted(ALLOWED_STATUSES),
+}
+
+
+def register_collection(conn: sqlite3.Connection) -> str:
+    existing = get_collection(conn, COLLECTION_NAME)
+    if existing:
+        return existing["collection_id"]
+    return create_collection(
+        conn,
+        COLLECTION_NAME,
+        "Append-only scenario-evidence ledger (latest record per SCN wins)",
+        COLLECTION_CONFIG,
+    )
+
+
+def scan_and_register(
+    conn: sqlite3.Connection,
+    root_dir: str | Path,
+) -> list[dict]:
+    root = Path(root_dir)
+    ledger_path = root / LEDGER_PATH
+    if not ledger_path.is_file():
+        logger.debug("scenario-ledger not present at %s; nothing to scan", ledger_path)
+        return []
+
+    col = get_collection(conn, COLLECTION_NAME)
+    if col is None:
+        raise ValueError(
+            f"Collection {COLLECTION_NAME!r} not registered. "
+            "Call register_collection() first."
+        )
+
+    latest: dict[str, dict] = {}
+    for line_no, raw in enumerate(ledger_path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            logger.warning("ledger line %d malformed: %s", line_no, exc)
+            continue
+        scn_id = record.get("scenario_id")
+        if not isinstance(scn_id, str):
+            logger.warning("ledger line %d missing scenario_id; skipped", line_no)
+            continue
+        timestamp = record.get("timestamp") or ""
+        prior = latest.get(scn_id)
+        if prior is None or str(timestamp) >= str(prior.get("timestamp") or ""):
+            latest[scn_id] = record
+
+    existing_ext_ids: set[str] = set()
+    for row in conn.execute(
+        "SELECT external_id FROM document "
+        "WHERE collection_id = ? AND external_id IS NOT NULL",
+        (col["collection_id"],),
+    ).fetchall():
+        existing_ext_ids.add(row["external_id"])
+
+    registered: list[dict] = []
+    for scn_id, record in latest.items():
+        if scn_id in existing_ext_ids:
+            continue
+        status = str(record.get("status") or "not-started").lower()
+        if status not in ALLOWED_STATUSES:
+            logger.warning(
+                "ledger entry %s has unknown status %r; storing as not-started",
+                scn_id, status,
+            )
+            status = "not-started"
+
+        tags: dict[str, str | list[str]] = {"scenario_id": scn_id, "status": status}
+        for key in ("chunk", "predicate_hash", "actor", "evidence_kind"):
+            val = record.get(key)
+            if val:
+                tags[key] = str(val)
+
+        title = f"{scn_id} :: {status}"
+        metadata = {"latest_record": record, "ledger_path": str(ledger_path)}
+
+        doc_id = register_document(
+            conn,
+            COLLECTION_NAME,
+            ledger_path,
+            "ledger-entry",
+            title,
+            tags=tags,
+            external_id=scn_id,
+            metadata=metadata,
+            status=status,
+        )
+        existing_ext_ids.add(scn_id)
+        registered.append(
+            {
+                "document_id": doc_id,
+                "scenario_id": scn_id,
+                "status": status,
+                "predicate_hash": record.get("predicate_hash"),
+            }
+        )
+
+    logger.info(
+        "Scanned ledger %s: %d unique SCN(s), %d newly registered",
+        ledger_path, len(latest), len(registered),
+    )
+    return registered

--- a/tests/test_scenario_ledger.py
+++ b/tests/test_scenario_ledger.py
@@ -1,0 +1,149 @@
+"""Tests for src/collections/scenario_ledger (issue #16)."""
+
+import json
+
+from src.collections.scenario_ledger import (
+    COLLECTION_NAME,
+    LEDGER_PATH,
+    register_collection,
+    scan_and_register,
+)
+from src.registry import get_collection, query_documents
+
+
+def _write_ledger(tmp_path, records):
+    path = tmp_path / LEDGER_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return path
+
+
+class TestRegisterCollection:
+    def test_creates_collection(self, db_conn):
+        cid = register_collection(db_conn)
+        assert len(cid) == 26
+        col = get_collection(db_conn, COLLECTION_NAME)
+        assert col is not None
+        assert col["name"] == COLLECTION_NAME
+        assert "passing" in col["config"]["statuses"]
+
+    def test_idempotent(self, db_conn):
+        a = register_collection(db_conn)
+        b = register_collection(db_conn)
+        assert a == b
+
+
+class TestScanAndRegister:
+    def test_no_ledger_file_returns_empty(self, db_conn, tmp_path):
+        register_collection(db_conn)
+        assert scan_and_register(db_conn, tmp_path) == []
+
+    def test_latest_record_wins(self, db_conn, tmp_path):
+        _write_ledger(
+            tmp_path,
+            [
+                {"scenario_id": "SCN-A", "status": "failing",
+                 "timestamp": "2026-05-01T00:00:00Z", "predicate_hash": "h1"},
+                {"scenario_id": "SCN-A", "status": "passing",
+                 "timestamp": "2026-05-04T00:00:00Z", "predicate_hash": "h2"},
+                {"scenario_id": "SCN-B", "status": "expected-fail",
+                 "timestamp": "2026-05-02T00:00:00Z", "predicate_hash": "h3"},
+            ],
+        )
+        register_collection(db_conn)
+        result = scan_and_register(db_conn, tmp_path)
+        assert len(result) == 2
+        by_id = {r["scenario_id"]: r for r in result}
+        assert by_id["SCN-A"]["status"] == "passing"
+        assert by_id["SCN-A"]["predicate_hash"] == "h2"
+        assert by_id["SCN-B"]["status"] == "expected-fail"
+
+    def test_status_enum_normalized(self, db_conn, tmp_path):
+        _write_ledger(
+            tmp_path,
+            [
+                {"scenario_id": "SCN-X", "status": "PASSING",
+                 "timestamp": "2026-05-01T00:00:00Z"},
+            ],
+        )
+        register_collection(db_conn)
+        scan_and_register(db_conn, tmp_path)
+        row = db_conn.execute(
+            "SELECT status FROM document WHERE external_id='SCN-X'"
+        ).fetchone()
+        assert row["status"] == "passing"
+
+    def test_unknown_status_falls_back_to_not_started(self, db_conn, tmp_path):
+        _write_ledger(
+            tmp_path,
+            [{"scenario_id": "SCN-Y", "status": "weird",
+              "timestamp": "2026-05-01T00:00:00Z"}],
+        )
+        register_collection(db_conn)
+        scan_and_register(db_conn, tmp_path)
+        row = db_conn.execute(
+            "SELECT status FROM document WHERE external_id='SCN-Y'"
+        ).fetchone()
+        assert row["status"] == "not-started"
+
+    def test_predicate_hash_indexed_as_tag(self, db_conn, tmp_path):
+        _write_ledger(
+            tmp_path,
+            [{"scenario_id": "SCN-Z", "status": "passing",
+              "timestamp": "2026-05-04T00:00:00Z",
+              "predicate_hash": "abc123", "chunk": "8.0t"}],
+        )
+        register_collection(db_conn)
+        scan_and_register(db_conn, tmp_path)
+        rows = db_conn.execute(
+            "SELECT tag_key, tag_value FROM document_tag dt "
+            "JOIN document d USING(document_id) "
+            "WHERE d.external_id='SCN-Z'"
+        ).fetchall()
+        tags = {r["tag_key"]: r["tag_value"] for r in rows}
+        assert tags.get("predicate_hash") == "abc123"
+        assert tags.get("chunk") == "8.0t"
+        assert tags.get("status") == "passing"
+
+    def test_idempotent_skip_existing(self, db_conn, tmp_path):
+        _write_ledger(
+            tmp_path,
+            [{"scenario_id": "SCN-A", "status": "passing",
+              "timestamp": "2026-05-04T00:00:00Z"}],
+        )
+        register_collection(db_conn)
+        first = scan_and_register(db_conn, tmp_path)
+        second = scan_and_register(db_conn, tmp_path)
+        assert len(first) == 1
+        assert second == []
+
+    def test_skips_malformed_lines(self, db_conn, tmp_path):
+        path = tmp_path / LEDGER_PATH
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            '{"scenario_id":"SCN-A","status":"passing","timestamp":"2026-05-04T00:00:00Z"}\n'
+            "{not json}\n"
+            '{"status":"passing"}\n'
+        )
+        register_collection(db_conn)
+        result = scan_and_register(db_conn, tmp_path)
+        assert len(result) == 1
+        assert result[0]["scenario_id"] == "SCN-A"
+
+    def test_query_by_status_tag(self, db_conn, tmp_path):
+        _write_ledger(
+            tmp_path,
+            [
+                {"scenario_id": "SCN-1", "status": "passing",
+                 "timestamp": "2026-05-04T00:00:00Z"},
+                {"scenario_id": "SCN-2", "status": "failing",
+                 "timestamp": "2026-05-04T00:00:00Z"},
+            ],
+        )
+        register_collection(db_conn)
+        scan_and_register(db_conn, tmp_path)
+        passing = query_documents(
+            db_conn, collection_name=COLLECTION_NAME, tags={"status": "passing"}
+        )
+        assert len(passing) == 1
+        assert passing[0]["external_id"] == "SCN-1"


### PR DESCRIPTION
Closes #16.

## Summary
- New `src/collections/scenario_ledger.py` — reads `artifacts/validation/scenario_ledger.jsonl` (append-only JSONL) and registers the latest record per `scenario_id` as a document keyed by `external_id`.
- Status enum mirrors `core/EVIDENCE_CONTRACT.md` (governance PR #20): `not-started`, `expected-fail`, `passing`, `failing`, `waived`. Unknown statuses fall back to `not-started` with a warning. Case is normalized.
- `predicate_hash` is stored as a tag so the join against scenario-predicates (#17) is a one-shot SQL query — drift between predicate definition and observed evidence becomes a JOIN result, not a manual diff.
- Idempotent on `(collection_id, external_id)`. Malformed JSONL lines are skipped with a warning, never abort the scan.
- Auto-discovered via the existing `src/collections/discovery.py` protocol.

## Coordination
- Pairs with **governance PR #22** (`SCENARIO_LEDGER_RUNBOOK.md`) which defines the JSONL writer/reader contract this plugin implements.
- Pairs with **#17** (predicate collection); the two collections share `predicate_hash` as the cross-reference key.
- Pairs with **governance PR #20** (`Scenario Status Vocabulary`) which ratifies the status enum.

## Test plan
- [x] 10 new tests pass: registration, latest-record-wins, status normalization, unknown-status fallback, predicate_hash tag indexing, idempotent re-scan, malformed-line tolerance, query by status tag
- [x] Full suite — 354/354 pass (one pre-existing perf test deselected)