### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "astaire"
-version = "0.3.1"
+version = "0.4.0"
 description = "Hybrid memory palace — structured knowledge store for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "astaire"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "tiktoken" },


### PR DESCRIPTION
## Summary

Cuts astaire **v0.4.0** over four merged PRs since v0.3.1:

- #18 `fix(scan)`: refresh modified documents alongside new registrations
- #19 `feat(#15)`: extend source_type taxonomy with governance-artifact types
- #20 `feat(#17)`: add scenario-predicate collection plugin
- #21 `feat(#16)`: add scenario-ledger collection plugin

## Validation

- `pytest`: 362 passed
- `pyproject.toml` and `uv.lock` bumped to 0.4.0

## Why now

Unblocks the three stacked ai-dev-governance drafts (cms-pm/ai-dev-governance#20/#21/#22) that consume the new collections, vocabulary, and adapter; ADG v0.7.0 will pin astaire @ v0.4.0 in the compatibility matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)