### PR TITLE
fix(scan): scenario-{ledger,predicate} return CLI-contract dict shape

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "astaire"
-version = "0.4.0"
+version = "0.4.1"
 description = "Hybrid memory palace — structured knowledge store for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/collections/scenario_ledger.py
+++ b/src/collections/scenario_ledger.py
@@ -140,6 +140,9 @@ def scan_and_register(
         registered.append(
             {
                 "document_id": doc_id,
+                "file_path": str(ledger_path),
+                "doc_type": "ledger-entry",
+                "title": title,
                 "scenario_id": scn_id,
                 "status": status,
                 "predicate_hash": record.get("predicate_hash"),

--- a/src/collections/scenario_predicate.py
+++ b/src/collections/scenario_predicate.py
@@ -138,9 +138,11 @@ def scan_and_register(
             registered.append(
                 {
                     "document_id": doc_id,
+                    "file_path": str(predicate_path),
+                    "doc_type": "predicate",
+                    "title": title,
                     "scenario_id": scn_id,
                     "predicate_hash": phash,
-                    "file_path": str(predicate_path),
                 }
             )
 

--- a/tests/test_scenario_ledger.py
+++ b/tests/test_scenario_ledger.py
@@ -57,6 +57,10 @@ class TestScanAndRegister:
         assert by_id["SCN-A"]["status"] == "passing"
         assert by_id["SCN-A"]["predicate_hash"] == "h2"
         assert by_id["SCN-B"]["status"] == "expected-fail"
+        for row in result:
+            assert "doc_type" in row and row["doc_type"] == "ledger-entry"
+            assert "title" in row and row["title"]
+            assert "file_path" in row and row["file_path"]
 
     def test_status_enum_normalized(self, db_conn, tmp_path):
         _write_ledger(

--- a/tests/test_scenario_predicate.py
+++ b/tests/test_scenario_predicate.py
@@ -88,6 +88,11 @@ class TestScanAndRegister:
         ext_ids = {d["external_id"] for d in docs}
         assert ext_ids == {"SCN-8.0t-01", "SCN-8.0t-03"}
 
+        for row in result:
+            assert "doc_type" in row and row["doc_type"] == "predicate"
+            assert "title" in row and row["title"]
+            assert "file_path" in row and row["file_path"]
+
     def test_idempotent_skip_existing(self, db_conn, tmp_path):
         _write_predicate(
             tmp_path,

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "astaire"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "tiktoken" },


### PR DESCRIPTION
## Summary

Fixes a v0.4.0 regression where `astaire scan` crashes with `KeyError: 'doc_type'` after registering documents through the new scenario-ledger (#16) or scenario-predicate (#17) collection plugins.

## Root cause

`cli.cmd_scan` formats every result row as `f\"  {doc['doc_type']:20s} {doc['title']}\"` — that's the contract `governance_authoring.scan_and_register` already follows. The two new plugins added in v0.4.0 returned `{document_id, scenario_id, …}` and `{document_id, scenario_id, predicate_hash, file_path}` respectively, omitting `doc_type` and `title`. Documents were registered correctly; only the summary print blew up.

## Fix

Each new plugin's returned dict now includes `doc_type`, `title`, `file_path` alongside its plugin-specific fields. Regression asserts added to the existing scan-and-register tests.

## Validation

- `pytest tests/test_scenario_ledger.py tests/test_scenario_predicate.py` → 20 passed
- Full suite: 361 passed; 1 unrelated perf-test flake (`test_tag_query_performance`, passes standalone)

Bumps version to 0.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)